### PR TITLE
introduce isocline (a readline alternative) and make multiline input default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/ggml"]
 	path = third_party/ggml
 	url = https://github.com/ggerganov/ggml.git
+[submodule "third_party/isocline"]
+	path = third_party/isocline
+	url = https://github.com/dingmaotu/isocline

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@ endif ()
 include_directories(third_party/ggml/include/ggml third_party/ggml/src)
 add_subdirectory(third_party/ggml)
 
+set(IC_BUILD_TESTS OFF CACHE BOOL "Build isocline without tests")
+include_directories(third_party/isocline/include third_party/isocline/src)
+add_subdirectory(third_party/isocline)
+
 if (GGML_CUBLAS)
     add_compile_definitions(GGML_USE_CUBLAS)
 endif ()
@@ -32,7 +36,7 @@ add_library(chatllm STATIC chat.cpp layers.cpp tokenizer.cpp models.cpp)
 target_link_libraries(chatllm PRIVATE ggml)
 
 add_executable(main main.cpp)
-target_link_libraries(main PRIVATE chatllm)
+target_link_libraries(main PRIVATE chatllm isocline)
 
 # GoogleTest
 option(CHATGLM_ENABLE_TESTING "chatllm: enable testing" OFF)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch
 tabulate
 tqdm
 transformers>=4.34.0
+sentencepiece


### PR DESCRIPTION
introduce `isocline` for convenient input editing, colors, and possibly other features.

1. --multi options is deleted as there is no need
2. should work on Windows (not tested)