### PR TITLE
Make _popen work on Linux

### DIFF
--- a/src/vision_process.cpp
+++ b/src/vision_process.cpp
@@ -13,7 +13,7 @@ namespace vision
 
         std::string cmd = "magick identify \"" + std::string(fn) + "\"";
 
-        FILE* pp = _popen(cmd.c_str(), "r");
+        FILE* pp = popen(cmd.c_str(), "r");
 
         while (!feof(pp))
         {
@@ -64,7 +64,7 @@ namespace vision
 
         printf("%s\n", oss.str().c_str());
 
-        FILE* pp = _popen(oss.str().c_str(), "rb");
+        FILE* pp = popen(oss.str().c_str(), "rb");
 
         while (!feof(pp))
         {


### PR DESCRIPTION
Hi :)

The build on Linux is currently failing due to _popen not being compatible with posix. Changing it to popen fixes this. It should still work on Windows with this change.

Linux/macOS: Use popen() (POSIX standard)
Windows: Requires _popen() (Microsoft-specific)

Thank you!