### PR TITLE
Use strcasecmp to fix Linux build

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -14,6 +14,13 @@
 #include <functional>
 #include "backend.h"
 
+#ifdef _WIN32
+#include <string.h>
+#define strcasecmp _stricmp
+#else
+#include <strings.h>
+#endif
+
 #include "ggml-cpu.h"
 
 #undef MIN
@@ -45,7 +52,7 @@ namespace chatllm
 
     bool ggml::str_to_type(const std::string &str, type *t)
     {
-        if (stricmp(str.c_str(), "q8") == 0)
+        if (strcasecmp(str.c_str(), "q8") == 0)
         {
             *t = ggml::type::GGML_TYPE_Q8_0;
             return true;
@@ -54,7 +61,7 @@ namespace chatllm
         for (int i = 0; i < GGML_TYPE_COUNT; ++i)
         {
             auto traits = ggml_get_type_traits((type)i);
-            if (stricmp(str.c_str(), traits->type_name) == 0)
+            if (strcasecmp(str.c_str(), traits->type_name) == 0)
             {
                 *t = (type)i;
                 return true;


### PR DESCRIPTION
Currently, the build is failing on Linux due to stricmp not being supported on Linux and possibly Mac. This fixes it but feel free to adjust. Thank you.