### PR TITLE
Fix critical crash: 'free(): invalid pointer' in CoreAttention

### DIFF
--- a/src/layers.h
+++ b/src/layers.h
@@ -1421,7 +1421,7 @@ namespace chatllm
               sinks(BlockParams::CoreAttentionUseSinks::get() > 0 ?
                     ggml::new_tensor_1d(ctx, ggml::type::GGML_TYPE_F32, BlockParams::CoreAttentionUseSinks::get())
                     : nullptr),
-              pos_helper(helper ? helper : &def_pos_helper)
+              pos_helper(helper ? helper : new BaseTensorPosHelper(max_length))
         {
             allocate_pos_tensor(ctx);
         }


### PR DESCRIPTION
This PR fixes a critical memory safety issue in `src/layers.h` where a `unique_ptr` was initialized with a stack address (`&def_pos_helper`). This caused a deterministic crash (`free(): invalid pointer`) during object destruction, affecting all models using this layer configuration.