### PR TITLE
Fix audio loading on Linux: use 'r' mode for popen

### DIFF
--- a/src/audio_process.cpp
+++ b/src/audio_process.cpp
@@ -46,7 +46,7 @@ namespace audio
 
         // Open pipe to ffmpeg process
         std::unique_ptr<FILE, decltype(&pclose)> pipe(
-            popen(oss.str().c_str(), "rb"),
+            popen(oss.str().c_str(), "r"),
             pclose
         );
 


### PR DESCRIPTION
This PR fixes a platform-specific bug in `src/audio_process.cpp` where `popen` was called with `"rb"` mode. On Linux/POSIX systems, only `"r"` or `"w"` are valid modes. This change ensures audio files can be loaded correctly on Linux.