### PR TITLE
Enable ASR support in Python binding and fix memory leaks

### DIFF
--- a/bindings/libchatllm.h
+++ b/bindings/libchatllm.h
@@ -248,6 +248,7 @@ DLL_DECL int API_CALL chatllm_user_input(struct chatllm_obj *obj, const char *ut
  * @param[in] obj               model object
  * @return                      0 if succeeded
  */
+DLL_DECL int API_CALL chatllm_destroy(struct chatllm_obj *obj);
 DLL_DECL int API_CALL chatllm_user_input_multimedia_msg(struct chatllm_obj *obj);
 
 /**

--- a/scripts/binding.py
+++ b/scripts/binding.py
@@ -1,6 +1,6 @@
 import sys, os
 
-this_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+this_dir = os.path.dirname(os.path.abspath(__file__))
 PATH_APP = os.path.abspath(os.path.join(this_dir, '..'))
 PATH_BINDS = os.path.join(PATH_APP, 'bindings')
 PATH_SCRIPTS = os.path.join(PATH_APP, 'scripts')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1865,13 +1865,20 @@ int chatllm_user_input(struct chatllm_obj *obj, const char *utf8_str)
 
     if (!chat->pipeline->is_loaded()) return -2;
 
-    if (    (chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::Chat)
+    if (    (chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::Chat && chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::ASR)
         &&  (chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::ASR))
         return -3;
 
     chat->history.push_back(utf8_str, role_user);
 
     return chatllm_generate(obj);
+}
+
+int chatllm_destroy(struct chatllm_obj *obj)
+{
+    Chat *chat = reinterpret_cast<Chat *>(obj);
+    delete chat;
+    return 0;
 }
 
 int chatllm_user_input_multimedia_msg(struct chatllm_obj *obj)
@@ -1882,7 +1889,7 @@ int chatllm_user_input_multimedia_msg(struct chatllm_obj *obj)
 
     if (!streamer->is_prompt) return -1;
 
-    if (chat->pipeline->is_loaded() && (chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::Chat))
+    if (chat->pipeline->is_loaded() && (chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::Chat && chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::ASR))
         return -1;
 
     chat->history.push_back(chat->content_scratch, role_user);
@@ -1907,7 +1914,7 @@ int chatllm_ai_continue(struct chatllm_obj *obj, const char *utf8_str)
 
     if (!streamer->is_prompt) return -1;
 
-    if (chat->pipeline->is_loaded() && (chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::Chat))
+    if (chat->pipeline->is_loaded() && (chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::Chat && chat->pipeline->model->get_purpose() != chatllm::ModelPurpose::ASR))
         return -1;
 
     if (chat->history.size() < 1) return -2;


### PR DESCRIPTION
This PR enables full ASR support in the Python bindings by:\n1. Allowing `user_input` for models with `ModelPurpose::ASR` (previously blocked).\n2. Exposing `chatllm_destroy` to Python to allow manual memory management, preventing memory leaks in long-running applications.\n3. Fixing the `binding.py` path resolution to work when imported as a module.