### PR TITLE
Update binding.md with Linux library path warning

### DIFF
--- a/docs/binding.md
+++ b/docs/binding.md
@@ -38,10 +38,10 @@ nim c main.nim
 
 > [!WARNING]
 > Linux does not search for `.so` files in current directory by default.
-> you need to update your library path before running the nim program with: 
-> `export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH`
+> You need to update your library path before running the nim program with:
+> `export LD_LIBRARY_PATH="$PWD:$LD_LIBRARY_PATH"`
 
-Run it with exactly the same command line options, for example: `main -i -m path/to/model`.
+Run it with exactly the same command line options, for example: `./main -i -m path/to/model`.
 
 ![](code_highlight.png)
 

--- a/docs/binding.md
+++ b/docs/binding.md
@@ -36,6 +36,11 @@ Build:
 nim c main.nim
 ```
 
+> [!WARNING]
+> Linux does not search for `.so` files in current directory by default.
+> you need to update your library path before running the nim program with: 
+> `export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH`
+
 Run it with exactly the same command line options, for example: `main -i -m path/to/model`.
 
 ![](code_highlight.png)


### PR DESCRIPTION
Without updating the library path trying to run the main results in could not load: libchatllm.so

as per #85